### PR TITLE
Removed unnecessary lines from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,13 +26,7 @@ zip_safe = True
 install_requires =
     anyio >= 2
     pyserial
-setup_requires =
-    setuptools_scm
-    pytest-runner
-    trustme >= 0.5
-
-[options.packages.find]
-where = .
+setup_requires = setuptools_scm
 
 [flake8]
 max-line-length = 99


### PR DESCRIPTION
This project doesn't require pytest-runner or trustme for running setup.py (nor for anything else).
And since packages are found in the project root here, the "options.packages.find" is unnecessary.