### PR TITLE
Avoid deprecated API: `anyio.to_thread.run_sync(cancellable)`

### DIFF
--- a/anyio_serial/_impl.py
+++ b/anyio_serial/_impl.py
@@ -46,8 +46,8 @@ class Serial(anyio.abc.ByteStream):
         if self._port is None:
             raise RuntimeError("Port not opened: %r %r", self._a, self._kw)
         async with anyio.create_task_group() as tg:
-            tg.start_soon(partial(anyio.to_thread.run_sync, self._read_worker, cancellable=True))
-            tg.start_soon(partial(anyio.to_thread.run_sync, self._write_worker, cancellable=True))
+            tg.start_soon(partial(anyio.to_thread.run_sync, self._read_worker, abandon_on_cancel=True))
+            tg.start_soon(partial(anyio.to_thread.run_sync, self._write_worker, abandon_on_cancel=True))
             try:
                 yield self
             finally:

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ packages = anyio_serial
 python_requires = >= 3.6.2
 zip_safe = True
 install_requires =
-    anyio >= 4
+    anyio >= 4.1
     pyserial
 setup_requires = setuptools_scm
 


### PR DESCRIPTION
hi! this fixes `DeprecationWarning`s on AnyIO >= 4.1.