### PR TITLE
Fix docstring SyntaxWarning

### DIFF
--- a/anyio_serial/_impl.py
+++ b/anyio_serial/_impl.py
@@ -198,9 +198,8 @@ class Serial(anyio.abc.ByteStream):
         self._port.break_condition = val
 
     async def send_break(self, duration=0.25):
-        """\ 
-        Send break condition. Timed, returns to idle state after given
-        duration.
+        """
+        Send break condition. Timed, returns to idle state after given duration.
         """
         self.break_condition = True
         await anyio.sleep(duration)

--- a/anyio_serial/_impl.py
+++ b/anyio_serial/_impl.py
@@ -203,5 +203,5 @@ class Serial(anyio.abc.ByteStream):
         """
         self.break_condition = True
         await anyio.sleep(duration)
-        self.break_condition = False  
+        self.break_condition = False
 


### PR DESCRIPTION
fixes `anyio_serial/_impl.py:201: SyntaxWarning: invalid escape sequence '\ '`.